### PR TITLE
Array flatMap: Inconsistent Parameter Name

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/flatmap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/flatmap/index.md
@@ -41,7 +41,7 @@ flatMap(function callbackFn(currentValue, index, array) { ... }, thisArg)
 
 ### Parameters
 
-- `callback`
+- `callbackFn`
 
   - : Function that produces an element of the new Array, taking three arguments:
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

In the syntax it says callbackFn, but in the parameter description it says callback: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap
